### PR TITLE
1.14 hot fix

### DIFF
--- a/pkg/v1/dense/value.go
+++ b/pkg/v1/dense/value.go
@@ -53,10 +53,11 @@ func FauxZeroValue(dt t.Dtype) interface{} {
 		return float32(FauxZero)
 	case reflect.Float64:
 		return float64(FauxZero)
-	case reflect.Complex64:
-		return complex64(FauxZero)
-	case reflect.Complex128:
-		return complex128(FauxZero)
+	// TODO: this breaks in 1.14
+	// case reflect.Complex64:
+	// 	return complex64(FauxZero)
+	// case reflect.Complex128:
+	// 	return complex128(FauxZero)
 	default:
 		panic(fmt.Sprintf("type not supported: %#v", dt))
 	}


### PR DESCRIPTION
A breaking change occurred in Go between 13.6 and 14.1 with float64 to complex64 casting, still need to investigate more
closes https://github.com/aunum/gold/issues/2